### PR TITLE
Add admin bypass feature

### DIFF
--- a/src/main/java/me/chunklock/ChunklockPlugin.java
+++ b/src/main/java/me/chunklock/ChunklockPlugin.java
@@ -35,7 +35,7 @@ public class ChunklockPlugin extends JavaPlugin {
         new TickTask(chunkLockManager, biomeUnlockRegistry).runTaskTimer(this, 0L, 10L);
         
         // Register commands
-        getCommand("chunklock").setExecutor(new ChunklockCommand(progressTracker));
+        getCommand("chunklock").setExecutor(new ChunklockCommand(progressTracker, chunkLockManager));
         
         getLogger().info("Chunklock plugin enabled with ChunkEvaluator integration!");
     }

--- a/src/main/java/me/chunklock/PlayerListener.java
+++ b/src/main/java/me/chunklock/PlayerListener.java
@@ -128,8 +128,12 @@ public class PlayerListener implements Listener {
 
         if (!from.equals(to)) {
             chunkLockManager.initializeChunk(to, event.getPlayer().getUniqueId());
+            Player player = event.getPlayer();
+            if (chunkLockManager.isBypassing(player)) {
+                return;
+            }
+
             if (chunkLockManager.isLocked(to)) {
-                Player player = event.getPlayer();
                 long now = System.currentTimeMillis();
                 long last = lastWarned.getOrDefault(player.getUniqueId(), 0L);
 

--- a/src/main/java/me/chunklock/TickTask.java
+++ b/src/main/java/me/chunklock/TickTask.java
@@ -21,6 +21,9 @@ public class TickTask extends BukkitRunnable {
     @Override
     public void run() {
         for (Player player : Bukkit.getOnlinePlayers()) {
+            if (chunkLockManager.isBypassing(player)) {
+                continue;
+            }
             Chunk center = player.getLocation().getChunk();
             chunkLockManager.initializeChunk(center, player.getUniqueId());
             maybeDrawBorder(player, center);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,7 +8,7 @@ description: Locks Minecraft chunks based on biome-specific item requirements.
 commands:
   chunklock:
     description: View your chunklock status or run admin commands
-    usage: /chunklock [status|reload|help|reset <player>]
+    usage: /chunklock [status|reload|bypass|help|reset <player>]
     permission: chunklock.admin
     aliases: [cl]
 


### PR DESCRIPTION
## Summary
- allow toggling a bypass mode for admins
- skip lock checks for bypassing players
- update plugin.yml usage

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6848a13f03cc832b962d4dda0ac446c2