### PR TITLE
Add admin bypass feature

### DIFF
--- a/src/main/java/me/chunklock/ChunklockCommand.java
+++ b/src/main/java/me/chunklock/ChunklockCommand.java
@@ -8,21 +8,27 @@ import org.bukkit.World;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.bukkit.entity.Player;
 
-public class ChunklockCommand implements CommandExecutor {
+public class ChunklockCommand implements CommandExecutor, TabCompleter {
 
     private final PlayerProgressTracker progressTracker;
+    private final ChunkLockManager chunkLockManager;
 
-    public ChunklockCommand(PlayerProgressTracker progressTracker) {
+    public ChunklockCommand(PlayerProgressTracker progressTracker, ChunkLockManager chunkLockManager) {
         this.progressTracker = progressTracker;
+        this.chunkLockManager = chunkLockManager;
     }
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
 
         if (args.length == 0) {
-            sender.sendMessage(Component.text("Usage: /chunklock <status|reset|help>").color(NamedTextColor.YELLOW));
+            sender.sendMessage(Component.text("Usage: /chunklock <status|reset|bypass|help>").color(NamedTextColor.YELLOW));
             return true;
         }
 
@@ -74,10 +80,40 @@ public class ChunklockCommand implements CommandExecutor {
                 target.sendMessage(Component.text("Your chunk progress and spawn were reset by an admin.").color(NamedTextColor.RED));
             }
 
+            case "bypass" -> {
+                if (!sender.hasPermission("chunklock.admin")) {
+                    sender.sendMessage(Component.text("You don't have permission to use this command.").color(NamedTextColor.RED));
+                    return true;
+                }
+
+                Player target;
+                if (args.length >= 2) {
+                    target = Bukkit.getPlayer(args[1]);
+                    if (target == null) {
+                        sender.sendMessage(Component.text("Player not found or not online.").color(NamedTextColor.RED));
+                        return true;
+                    }
+                } else {
+                    if (!(sender instanceof Player p)) {
+                        sender.sendMessage(Component.text("Only players can toggle their own bypass.").color(NamedTextColor.RED));
+                        return true;
+                    }
+                    target = p;
+                }
+
+                chunkLockManager.setBypassing(target, !chunkLockManager.isBypassing(target));
+                boolean state = chunkLockManager.isBypassing(target);
+                sender.sendMessage(Component.text("Chunklock bypass " + (state ? "enabled" : "disabled") + " for " + target.getName()).color(NamedTextColor.GREEN));
+                if (sender != target) {
+                    target.sendMessage(Component.text("Chunklock bypass " + (state ? "enabled" : "disabled") + " by admin.").color(NamedTextColor.YELLOW));
+                }
+            }
+
             case "help" -> {
                 sender.sendMessage(Component.text("Chunklock Commands:").color(NamedTextColor.AQUA));
                 sender.sendMessage(Component.text("/chunklock status - View your unlocked chunks").color(NamedTextColor.GRAY));
                 sender.sendMessage(Component.text("/chunklock reset <player> - Admin: Reset a player's chunks and spawn").color(NamedTextColor.GRAY));
+                sender.sendMessage(Component.text("/chunklock bypass [player] - Admin: Toggle bypass mode").color(NamedTextColor.GRAY));
             }
 
             default -> {
@@ -86,5 +122,32 @@ public class ChunklockCommand implements CommandExecutor {
         }
 
         return true;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        List<String> completions = new ArrayList<>();
+
+        if (args.length == 1) {
+            String prefix = args[0].toLowerCase();
+            for (String sub : List.of("status", "reset", "bypass", "help")) {
+                if (sub.startsWith(prefix)) {
+                    completions.add(sub);
+                }
+            }
+            return completions;
+        }
+
+        if (args.length == 2 && (args[0].equalsIgnoreCase("reset") || args[0].equalsIgnoreCase("bypass"))) {
+            String prefix = args[1].toLowerCase();
+            for (Player p : Bukkit.getOnlinePlayers()) {
+                if (p.getName().toLowerCase().startsWith(prefix)) {
+                    completions.add(p.getName());
+                }
+            }
+            return completions;
+        }
+
+        return Collections.emptyList();
     }
 }

--- a/src/main/java/me/chunklock/ChunklockPlugin.java
+++ b/src/main/java/me/chunklock/ChunklockPlugin.java
@@ -35,7 +35,9 @@ public class ChunklockPlugin extends JavaPlugin {
         new TickTask(chunkLockManager, biomeUnlockRegistry).runTaskTimer(this, 0L, 10L);
         
         // Register commands
-        getCommand("chunklock").setExecutor(new ChunklockCommand(progressTracker));
+        var chunklockCmd = new ChunklockCommand(progressTracker, chunkLockManager);
+        getCommand("chunklock").setExecutor(chunklockCmd);
+        getCommand("chunklock").setTabCompleter(chunklockCmd);
         
         getLogger().info("Chunklock plugin enabled with ChunkEvaluator integration!");
     }

--- a/src/main/java/me/chunklock/PlayerListener.java
+++ b/src/main/java/me/chunklock/PlayerListener.java
@@ -128,8 +128,12 @@ public class PlayerListener implements Listener {
 
         if (!from.equals(to)) {
             chunkLockManager.initializeChunk(to, event.getPlayer().getUniqueId());
+            Player player = event.getPlayer();
+            if (chunkLockManager.isBypassing(player)) {
+                return;
+            }
+
             if (chunkLockManager.isLocked(to)) {
-                Player player = event.getPlayer();
                 long now = System.currentTimeMillis();
                 long last = lastWarned.getOrDefault(player.getUniqueId(), 0L);
 

--- a/src/main/java/me/chunklock/TickTask.java
+++ b/src/main/java/me/chunklock/TickTask.java
@@ -21,6 +21,9 @@ public class TickTask extends BukkitRunnable {
     @Override
     public void run() {
         for (Player player : Bukkit.getOnlinePlayers()) {
+            if (chunkLockManager.isBypassing(player)) {
+                continue;
+            }
             Chunk center = player.getLocation().getChunk();
             chunkLockManager.initializeChunk(center, player.getUniqueId());
             maybeDrawBorder(player, center);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,7 +8,7 @@ description: Locks Minecraft chunks based on biome-specific item requirements.
 commands:
   chunklock:
     description: View your chunklock status or run admin commands
-    usage: /chunklock [status|reload|help|reset <player>]
+    usage: /chunklock [status|reset <player>|bypass [player]|help]
     permission: chunklock.admin
     aliases: [cl]
 


### PR DESCRIPTION
## Summary
- allow toggling a bypass mode for admins
- skip lock checks for bypassing players
- update plugin.yml usage
- hook up tab completion for commands

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6848a13f03cc832b962d4dda0ac446c2