### PR TITLE
Add unlock GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # chunklock
-Chunklock minecraft plugin
+Chunklock is a Minecraft plugin that restricts players to specific chunks until they unlock them. Chunks can be unlocked by providing biome specific items. The plugin also tracks how many chunks each player has unlocked.
+
+## Commands
+
+- `/chunklock status` – show how many chunks you have unlocked.
+- `/chunklock unlock` – open a small GUI to attempt unlocking the chunk you are standing in.
+- `/chunklock bypass [player]` – admin: toggle bypass mode for a player.
+- `/chunklock reset <player>` – admin: reset a player's progress.

--- a/src/main/java/me/chunklock/ChunklockCommand.java
+++ b/src/main/java/me/chunklock/ChunklockCommand.java
@@ -13,22 +13,27 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.bukkit.entity.Player;
+import org.bukkit.Chunk;
+
+import me.chunklock.UnlockGui;
 
 public class ChunklockCommand implements CommandExecutor, TabCompleter {
 
     private final PlayerProgressTracker progressTracker;
     private final ChunkLockManager chunkLockManager;
+    private final UnlockGui unlockGui;
 
-    public ChunklockCommand(PlayerProgressTracker progressTracker, ChunkLockManager chunkLockManager) {
+    public ChunklockCommand(PlayerProgressTracker progressTracker, ChunkLockManager chunkLockManager, UnlockGui unlockGui) {
         this.progressTracker = progressTracker;
         this.chunkLockManager = chunkLockManager;
+        this.unlockGui = unlockGui;
     }
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
 
         if (args.length == 0) {
-            sender.sendMessage(Component.text("Usage: /chunklock <status|reset|bypass|help>").color(NamedTextColor.YELLOW));
+            sender.sendMessage(Component.text("Usage: /chunklock <status|reset|bypass|unlock|help>").color(NamedTextColor.YELLOW));
             return true;
         }
 
@@ -109,11 +114,21 @@ public class ChunklockCommand implements CommandExecutor, TabCompleter {
                 }
             }
 
+            case "unlock" -> {
+                if (!(sender instanceof Player player)) {
+                    sender.sendMessage(Component.text("Only players can unlock chunks.").color(NamedTextColor.RED));
+                    return true;
+                }
+                Chunk chunk = player.getLocation().getChunk();
+                unlockGui.open(player, chunk);
+            }
+
             case "help" -> {
                 sender.sendMessage(Component.text("Chunklock Commands:").color(NamedTextColor.AQUA));
                 sender.sendMessage(Component.text("/chunklock status - View your unlocked chunks").color(NamedTextColor.GRAY));
                 sender.sendMessage(Component.text("/chunklock reset <player> - Admin: Reset a player's chunks and spawn").color(NamedTextColor.GRAY));
                 sender.sendMessage(Component.text("/chunklock bypass [player] - Admin: Toggle bypass mode").color(NamedTextColor.GRAY));
+                sender.sendMessage(Component.text("/chunklock unlock - Attempt to unlock your current chunk").color(NamedTextColor.GRAY));
             }
 
             default -> {
@@ -130,7 +145,7 @@ public class ChunklockCommand implements CommandExecutor, TabCompleter {
 
         if (args.length == 1) {
             String prefix = args[0].toLowerCase();
-            for (String sub : List.of("status", "reset", "bypass", "help")) {
+            for (String sub : List.of("status", "reset", "bypass", "unlock", "help")) {
                 if (sub.startsWith(prefix)) {
                     completions.add(sub);
                 }

--- a/src/main/java/me/chunklock/ChunklockPlugin.java
+++ b/src/main/java/me/chunklock/ChunklockPlugin.java
@@ -3,6 +3,8 @@ package me.chunklock;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import me.chunklock.UnlockGui;
+
 public class ChunklockPlugin extends JavaPlugin {
 
     private static ChunklockPlugin instance;
@@ -12,6 +14,7 @@ public class ChunklockPlugin extends JavaPlugin {
     private PlayerDataManager playerDataManager;
     private ChunkValueRegistry chunkValueRegistry;
     private ChunkEvaluator chunkEvaluator;
+    private UnlockGui unlockGui;
 
     @Override
     public void onEnable() {
@@ -30,12 +33,14 @@ public class ChunklockPlugin extends JavaPlugin {
         // Register event listeners
         Bukkit.getPluginManager().registerEvents(new PlayerListener(chunkLockManager, progressTracker, playerDataManager), this);
         Bukkit.getPluginManager().registerEvents(new UnlockItemListener(chunkLockManager, biomeUnlockRegistry, progressTracker), this);
+        this.unlockGui = new UnlockGui(chunkLockManager, biomeUnlockRegistry, progressTracker);
+        Bukkit.getPluginManager().registerEvents(unlockGui, this);
 
         // Start tick task for visual effects
         new TickTask(chunkLockManager, biomeUnlockRegistry).runTaskTimer(this, 0L, 10L);
         
         // Register commands
-        var chunklockCmd = new ChunklockCommand(progressTracker, chunkLockManager);
+        var chunklockCmd = new ChunklockCommand(progressTracker, chunkLockManager, unlockGui);
         getCommand("chunklock").setExecutor(chunklockCmd);
         getCommand("chunklock").setTabCompleter(chunklockCmd);
         
@@ -61,5 +66,9 @@ public class ChunklockPlugin extends JavaPlugin {
     
     public ChunkEvaluator getChunkEvaluator() {
         return chunkEvaluator;
+    }
+
+    public UnlockGui getUnlockGui() {
+        return unlockGui;
     }
 }

--- a/src/main/java/me/chunklock/UnlockGui.java
+++ b/src/main/java/me/chunklock/UnlockGui.java
@@ -1,0 +1,99 @@
+package me.chunklock;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
+import org.bukkit.Chunk;
+import org.bukkit.Material;
+import org.bukkit.block.Biome;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class UnlockGui implements Listener {
+    private final ChunkLockManager chunkLockManager;
+    private final BiomeUnlockRegistry biomeUnlockRegistry;
+    private final PlayerProgressTracker progressTracker;
+
+    private final Map<UUID, Chunk> pending = new HashMap<>();
+
+    private static final String GUI_TITLE = "Unlock Chunk";
+
+    public UnlockGui(ChunkLockManager chunkLockManager,
+                     BiomeUnlockRegistry biomeUnlockRegistry,
+                     PlayerProgressTracker progressTracker) {
+        this.chunkLockManager = chunkLockManager;
+        this.biomeUnlockRegistry = biomeUnlockRegistry;
+        this.progressTracker = progressTracker;
+    }
+
+    public void open(Player player, Chunk chunk) {
+        Biome biome = chunk.getBlock(8, player.getLocation().getBlockY(), 8).getBiome();
+        List<Material> items = biomeUnlockRegistry.getRequiredItems(biome);
+
+        Inventory inv = Bukkit.createInventory(null, 9, Component.text(GUI_TITLE));
+
+        int slot = 0;
+        for (Material mat : items) {
+            ItemStack stack = new ItemStack(mat);
+            ItemMeta meta = stack.getItemMeta();
+            meta.displayName(Component.text(mat.name()).color(NamedTextColor.YELLOW));
+            stack.setItemMeta(meta);
+            inv.setItem(slot++, stack);
+        }
+
+        ItemStack unlock = new ItemStack(Material.EMERALD_BLOCK);
+        ItemMeta meta = unlock.getItemMeta();
+        meta.displayName(Component.text("Click to Unlock").color(NamedTextColor.GREEN));
+        unlock.setItemMeta(meta);
+        inv.setItem(8, unlock);
+
+        pending.put(player.getUniqueId(), chunk);
+        player.openInventory(inv);
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player player)) return;
+        if (!event.getView().title().equals(Component.text(GUI_TITLE))) return;
+
+        event.setCancelled(true);
+        if (event.getRawSlot() != 8) return;
+
+        Chunk chunk = pending.get(player.getUniqueId());
+        if (chunk == null) return;
+        if (!chunkLockManager.isLocked(chunk)) {
+            player.sendMessage(Component.text("Chunk already unlocked.").color(NamedTextColor.GRAY));
+            return;
+        }
+
+        Biome biome = chunk.getBlock(8, player.getLocation().getBlockY(), 8).getBiome();
+        if (!biomeUnlockRegistry.hasRequiredItems(player, biome)) {
+            player.sendMessage(Component.text("Missing required items: " + biomeUnlockRegistry.getRequiredItems(biome)).color(NamedTextColor.RED));
+            return;
+        }
+
+        biomeUnlockRegistry.consumeRequiredItem(player, biome);
+        chunkLockManager.unlockChunk(chunk);
+        progressTracker.incrementUnlockedChunks(player.getUniqueId());
+
+        int total = progressTracker.getUnlockedChunkCount(player.getUniqueId());
+        player.sendMessage(Component.text("Chunk unlocked! Total unlocked chunks: " + total).color(NamedTextColor.GREEN));
+        player.closeInventory();
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent event) {
+        pending.remove(event.getPlayer().getUniqueId());
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,7 +8,7 @@ description: Locks Minecraft chunks based on biome-specific item requirements.
 commands:
   chunklock:
     description: View your chunklock status or run admin commands
-    usage: /chunklock [status|reset <player>|bypass [player]|help]
+    usage: /chunklock [status|reset <player>|bypass [player]|unlock|help]
     permission: chunklock.admin
     aliases: [cl]
 


### PR DESCRIPTION
## Summary
- implement an `UnlockGui` class for a simple chest GUI
- register the GUI listener and expose it
- extend `/chunklock` command with an `unlock` option
- document commands

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68496a6bf414832b85a8cb2975120d3b