### PR TITLE
Add persistent chunk data

### DIFF
--- a/src/main/java/me/chunklock/ChunkLockManager.java
+++ b/src/main/java/me/chunklock/ChunkLockManager.java
@@ -2,7 +2,12 @@ package me.chunklock;
 
 import org.bukkit.Chunk;
 import org.bukkit.entity.Player;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -13,9 +18,15 @@ public class ChunkLockManager {
 
     private final Map<String, ChunkData> chunkDataMap = new HashMap<>();
     private final ChunkEvaluator chunkEvaluator;
+    private final JavaPlugin plugin;
+    private final File file;
+    private FileConfiguration config;
 
-    public ChunkLockManager(ChunkEvaluator chunkEvaluator) {
+    public ChunkLockManager(ChunkEvaluator chunkEvaluator, JavaPlugin plugin) {
         this.chunkEvaluator = chunkEvaluator;
+        this.plugin = plugin;
+        this.file = new File(plugin.getDataFolder(), "chunk_data.yml");
+        loadAll();
     }
 
     public boolean isLocked(Chunk chunk) {
@@ -34,6 +45,71 @@ public class ChunkLockManager {
     public void unlockChunk(Chunk chunk) {
         ChunkData data = getChunkData(chunk);
         data.setLocked(false);
+    }
+
+    private void loadAll() {
+        if (!file.exists()) {
+            try {
+                file.getParentFile().mkdirs();
+                file.createNewFile();
+            } catch (IOException e) {
+                plugin.getLogger().severe("Could not create chunk_data.yml");
+                return;
+            }
+        }
+
+        config = YamlConfiguration.loadConfiguration(file);
+
+        for (String key : config.getKeys(false)) {
+            try {
+                String world = config.getString(key + ".world");
+                int x = config.getInt(key + ".x");
+                int z = config.getInt(key + ".z");
+                boolean locked = config.getBoolean(key + ".locked", true);
+                String diffStr = config.getString(key + ".difficulty", "NORMAL");
+                Difficulty diff = Difficulty.valueOf(diffStr.toUpperCase());
+
+                String mapKey = world + ":" + x + ":" + z;
+                chunkDataMap.put(mapKey, new ChunkData(locked, diff));
+            } catch (Exception e) {
+                plugin.getLogger().warning("Failed to load chunk entry: " + key);
+            }
+        }
+
+        plugin.getLogger().info("Loaded " + chunkDataMap.size() + " chunks from chunk_data.yml");
+    }
+
+    public void saveAll() {
+        if (config == null) {
+            config = new YamlConfiguration();
+        }
+
+        for (String key : config.getKeys(false)) {
+            config.set(key, null); // Clear existing entries
+        }
+
+        for (Map.Entry<String, ChunkData> entry : chunkDataMap.entrySet()) {
+            String[] parts = entry.getKey().split(":");
+            if (parts.length != 3) continue;
+
+            String world = parts[0];
+            int x = Integer.parseInt(parts[1]);
+            int z = Integer.parseInt(parts[2]);
+            String base = entry.getKey();
+
+            config.set(base + ".world", world);
+            config.set(base + ".x", x);
+            config.set(base + ".z", z);
+            config.set(base + ".locked", entry.getValue().isLocked());
+            config.set(base + ".difficulty", entry.getValue().getDifficulty().name());
+        }
+
+        try {
+            config.save(file);
+            plugin.getLogger().info("Saved chunk data to chunk_data.yml");
+        } catch (IOException e) {
+            plugin.getLogger().severe("Could not save chunk_data.yml");
+        }
     }
 
     public void initializeChunk(Chunk chunk, UUID playerId) {

--- a/src/main/java/me/chunklock/ChunklockPlugin.java
+++ b/src/main/java/me/chunklock/ChunklockPlugin.java
@@ -31,7 +31,7 @@ public class ChunklockPlugin extends JavaPlugin {
         
         // Initialize evaluator and manager
         this.chunkEvaluator = new ChunkEvaluator(playerDataManager, chunkValueRegistry);
-        this.chunkLockManager = new ChunkLockManager(chunkEvaluator);
+        this.chunkLockManager = new ChunkLockManager(chunkEvaluator, this);
 
         // Register event listeners
         this.unlockGui = new UnlockGui(chunkLockManager, biomeUnlockRegistry, progressTracker);
@@ -57,6 +57,9 @@ public class ChunklockPlugin extends JavaPlugin {
         }
         if (teamManager != null) {
             teamManager.saveAll();
+        }
+        if (chunkLockManager != null) {
+            chunkLockManager.saveAll();
         }
         getLogger().info("Chunklock plugin disabled.");
     }


### PR DESCRIPTION
## Summary
- persist chunk state between restarts
- load and save to `chunk_data.yml`
- update plugin startup and shutdown

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498b521a6c832bbd27ed01106aec99