### PR TITLE
Clamp scanning to world min height

### DIFF
--- a/src/main/java/me/chunklock/ChunkEvaluator.java
+++ b/src/main/java/me/chunklock/ChunkEvaluator.java
@@ -67,10 +67,16 @@ public class ChunkEvaluator {
 
     private int scanSurfaceBlocks(Chunk chunk) {
         int score = 0;
+        var world = chunk.getWorld();
+        int minY = world.getMinHeight();
         for (int x = 0; x < 16; x += SCAN_STEP) {
             for (int z = 0; z < 16; z += SCAN_STEP) {
-                int y = chunk.getWorld().getHighestBlockYAt(chunk.getBlock(x, 0, z).getLocation());
-                Block block = chunk.getBlock(x, y - 1, z);
+                int y = world.getHighestBlockYAt(chunk.getBlock(x, 0, z).getLocation());
+                if (y <= minY) {
+                    continue;
+                }
+                int sampleY = Math.max(minY, y - 1);
+                Block block = chunk.getBlock(x, sampleY, z);
                 Material mat = block.getType();
                 score += chunkValueRegistry.getBlockWeight(mat);
             }

--- a/src/test/java/me/chunklock/ChunkEvaluatorTest.java
+++ b/src/test/java/me/chunklock/ChunkEvaluatorTest.java
@@ -49,4 +49,37 @@ class ChunkEvaluatorTest {
         assertEquals(Biome.PLAINS, result.biome); // default from mock
         assertEquals(Difficulty.EASY, result.difficulty);
     }
+
+    @Test
+    void handlesMinHeightSample() {
+        JavaPlugin plugin = Mockito.mock(JavaPlugin.class);
+        Mockito.when(plugin.getDataFolder()).thenReturn(new java.io.File("."));
+        Mockito.when(plugin.getLogger()).thenReturn(Logger.getLogger("test"));
+
+        ChunkValueRegistry reg = Mockito.mock(ChunkValueRegistry.class);
+        Mockito.when(reg.getBiomeWeight(Mockito.any())).thenReturn(0);
+        Mockito.when(reg.getBlockWeight(Mockito.any())).thenReturn(0);
+        Mockito.when(reg.getThreshold("easy")).thenReturn(10);
+        Mockito.when(reg.getThreshold("normal")).thenReturn(20);
+        Mockito.when(reg.getThreshold("hard")).thenReturn(30);
+
+        PlayerDataManager pdm = Mockito.mock(PlayerDataManager.class);
+        World world = Mockito.mock(World.class);
+        Mockito.when(world.getMinHeight()).thenReturn(0);
+        Location spawn = new Location(world, 0, 0, 0);
+        Mockito.when(pdm.getChunkSpawn(Mockito.any())).thenReturn(spawn);
+
+        Chunk chunk = Mockito.mock(Chunk.class);
+        Mockito.when(chunk.getX()).thenReturn(0);
+        Mockito.when(chunk.getZ()).thenReturn(0);
+        Mockito.when(chunk.getWorld()).thenReturn(world);
+        Block block = Mockito.mock(Block.class);
+        Mockito.when(block.getType()).thenReturn(org.bukkit.Material.AIR);
+        Mockito.when(block.getBiome()).thenReturn(Biome.PLAINS);
+        Mockito.when(chunk.getBlock(Mockito.anyInt(), Mockito.anyInt(), Mockito.anyInt())).thenReturn(block);
+        Mockito.when(world.getHighestBlockYAt(Mockito.any(Location.class))).thenReturn(0);
+
+        ChunkEvaluator eval = new ChunkEvaluator(pdm, reg);
+        assertDoesNotThrow(() -> eval.evaluateChunk(UUID.randomUUID(), chunk));
+    }
 }


### PR DESCRIPTION
## Summary
- avoid sampling blocks below world min height
- test evaluator handles minimum height returned from `getHighestBlockYAt`

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849a3c274a8832b9c1baadd7a7a1c82