### PR TITLE
Fix border removal when unlocking chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Chunklock transforms Minecraft into a strategic progression-based survival game.
 - **Difficulty tiers (Easy → Impossible)**
 - **Fully configurable scoring system via `config.yml`**
 - **Supports both solo and team play**
+- **Chunk borders rise from bedrock to build limit**
 
 ---
 


### PR DESCRIPTION
## Summary
- remove shared glass walls when chunks on either side are unlocked
- add utility to get the opposite direction
- ensure getBorderChunk checks the chunk the glass block is placed in first
- extend borders from bedrock all the way to the build limit

## Testing
- `mvn -DskipTests package`

------
https://chatgpt.com/codex/tasks/task_e_6852d8066a88832b80f8de29d188789e