### PR TITLE
Fix border reset and interaction logic

### DIFF
--- a/src/main/java/me/chunklock/ChunklockCommand.java
+++ b/src/main/java/me/chunklock/ChunklockCommand.java
@@ -194,7 +194,7 @@ public class ChunklockCommand implements CommandExecutor, TabCompleter {
                 // Regenerate borders for the player immediately
                 ChunkBorderManager borderManager = ChunklockPlugin.getInstance().getChunkBorderManager();
                 if (borderManager != null) {
-                    borderManager.scheduleBorderUpdate(target);
+                    borderManager.updateBordersForPlayer(target);
                 }
             }
 


### PR DESCRIPTION
## Summary
- regenerate borders immediately on player reset
- map glass borders to locked chunks and add helper to fetch target chunk
- use helper during interaction to open GUI only if chunk is locked

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_6854328cd238832b9445ad02945f6347