### PR TITLE
Add team-based contested claims

### DIFF
--- a/src/main/java/me/chunklock/ChunkBorderManager.java
+++ b/src/main/java/me/chunklock/ChunkBorderManager.java
@@ -33,6 +33,8 @@ public class ChunkBorderManager implements Listener {
     private final ChunkLockManager chunkLockManager;
     private final UnlockGui unlockGui;
     private final JavaPlugin plugin;
+    private final TeamManager teamManager;
+    private final PlayerProgressTracker progressTracker;
     
     // Store border blocks per player: Player UUID -> Location -> Original BlockData
     private final Map<UUID, Map<Location, BlockData>> playerBorders = new ConcurrentHashMap<>();
@@ -54,6 +56,8 @@ public class ChunkBorderManager implements Listener {
     private boolean restoreOriginalBlocks;
     private boolean debugLogging;
     private Material borderMaterial;
+    private Material ownBorderMaterial = Material.LIME_STAINED_GLASS;
+    private Material enemyBorderMaterial = Material.RED_STAINED_GLASS;
     private boolean skipValuableOres;
     private boolean skipFluids;
     private boolean skipImportantBlocks;
@@ -61,9 +65,11 @@ public class ChunkBorderManager implements Listener {
     private int maxBorderUpdatesPerTick = 10;
     private final Queue<Runnable> updateQueue = new ConcurrentLinkedQueue<>();
 
-    public ChunkBorderManager(ChunkLockManager chunkLockManager, UnlockGui unlockGui) {
+    public ChunkBorderManager(ChunkLockManager chunkLockManager, UnlockGui unlockGui, TeamManager teamManager, PlayerProgressTracker progressTracker) {
         this.chunkLockManager = chunkLockManager;
         this.unlockGui = unlockGui;
+        this.teamManager = teamManager;
+        this.progressTracker = progressTracker;
         this.plugin = ChunklockPlugin.getInstance();
 
         loadConfiguration();
@@ -585,12 +591,21 @@ public class ChunkBorderManager implements Listener {
                 try {
                     Block block = loc.getBlock();
                     if (shouldSkipBlock(block)) continue;
-                    if (block.getType() == borderMaterial) continue;
+                    if (block.getType() == borderMaterial || block.getType() == ownBorderMaterial || block.getType() == enemyBorderMaterial) continue;
 
                     playerMap.put(loc, block.getBlockData().clone());
                     // Map this border block to the locked chunk it protects
                     borderToChunk.put(loc, lockedCoord);
-                    block.setType(borderMaterial);
+
+                    Chunk neighbor = chunk.getWorld().getChunkAt(lockedX, lockedZ);
+                    UUID owner = chunkLockManager.getChunkOwner(neighbor);
+                    UUID teamId = teamManager.getTeamLeader(player.getUniqueId());
+                    Material mat = borderMaterial;
+                    if (owner != null) {
+                        mat = owner.equals(teamId) ? ownBorderMaterial : enemyBorderMaterial;
+                    }
+
+                    block.setType(mat);
                 } catch (Exception e) {
                     if (debugLogging) {
                         plugin.getLogger().log(Level.FINE, "Error placing border block at " + loc, e);
@@ -786,7 +801,11 @@ public class ChunkBorderManager implements Listener {
         }
         
         Block clickedBlock = event.getClickedBlock();
-        if (clickedBlock == null || clickedBlock.getType() != borderMaterial) {
+        if (clickedBlock == null) {
+            return;
+        }
+        Material type = clickedBlock.getType();
+        if (type != borderMaterial && type != ownBorderMaterial && type != enemyBorderMaterial) {
             return;
         }
 
@@ -807,6 +826,17 @@ public class ChunkBorderManager implements Listener {
             
             // Verify the chunk is still locked
             if (chunkLockManager.isLocked(chunk)) {
+                UUID teamId = teamManager.getTeamLeader(player.getUniqueId());
+                boolean contested = chunkLockManager.isContestedChunk(chunk, teamId);
+
+                if (contested) {
+                    int maxClaims = chunkLockManager.getMaxContestedClaimsPerDay();
+                    if (!progressTracker.canClaimContested(teamId, maxClaims)) {
+                        player.sendMessage("§cYour team reached the contested claim limit for today.");
+                        return;
+                    }
+                }
+
                 unlockGui.open(player, chunk);
 
                 // Show chunk info

--- a/src/main/java/me/chunklock/ChunkData.java
+++ b/src/main/java/me/chunklock/ChunkData.java
@@ -1,12 +1,20 @@
 package me.chunklock;
 
+import java.util.UUID;
+
 public class ChunkData {
     private boolean locked;
     private Difficulty difficulty;
+    private UUID ownerId;
 
     public ChunkData(boolean locked, Difficulty difficulty) {
+        this(locked, difficulty, null);
+    }
+
+    public ChunkData(boolean locked, Difficulty difficulty, UUID ownerId) {
         this.locked = locked;
         this.difficulty = difficulty;
+        this.ownerId = ownerId;
     }
 
     public boolean isLocked() {
@@ -23,5 +31,13 @@ public class ChunkData {
 
     public void setDifficulty(Difficulty difficulty) {
         this.difficulty = difficulty;
+    }
+
+    public UUID getOwnerId() {
+        return ownerId;
+    }
+
+    public void setOwnerId(UUID ownerId) {
+        this.ownerId = ownerId;
     }
 }

--- a/src/main/java/me/chunklock/ChunklockCommand.java
+++ b/src/main/java/me/chunklock/ChunklockCommand.java
@@ -718,7 +718,8 @@ public class ChunklockCommand implements CommandExecutor, TabCompleter {
                 
             } else if (args.length > 1 && args[1].equalsIgnoreCase("force")) {
                 // Force unlock without items
-                chunkLockManager.unlockChunk(currentChunk);
+                UUID teamId = chunkLockManager.getTeamManager().getTeamLeader(player.getUniqueId());
+                chunkLockManager.unlockChunk(currentChunk, teamId);
                 progressTracker.incrementUnlockedChunks(player.getUniqueId());
                 
                 player.sendMessage(Component.text("✓ Force unlocked chunk").color(NamedTextColor.GREEN));

--- a/src/main/java/me/chunklock/ChunklockPlugin.java
+++ b/src/main/java/me/chunklock/ChunklockPlugin.java
@@ -280,8 +280,8 @@ public class ChunklockPlugin extends JavaPlugin implements Listener {
             this.biomeUnlockRegistry = new BiomeUnlockRegistry(this, progressTracker);
             this.playerDataManager = new PlayerDataManager(this);
             this.chunkEvaluator = new ChunkEvaluator(playerDataManager, chunkValueRegistry);
-            this.chunkLockManager = new ChunkLockManager(chunkEvaluator, this);
-            this.unlockGui = new UnlockGui(chunkLockManager, biomeUnlockRegistry, progressTracker);
+            this.chunkLockManager = new ChunkLockManager(chunkEvaluator, this, teamManager);
+            this.unlockGui = new UnlockGui(chunkLockManager, biomeUnlockRegistry, progressTracker, teamManager);
             this.hologramManager = new HologramManager(chunkLockManager, biomeUnlockRegistry);
             this.playerListener = new PlayerListener(chunkLockManager, progressTracker, playerDataManager, unlockGui);
             
@@ -289,7 +289,7 @@ public class ChunklockPlugin extends JavaPlugin implements Listener {
             this.blockProtectionListener = new BlockProtectionListener(chunkLockManager, unlockGui);
             
             // Initialize glass border system
-            this.chunkBorderManager = new ChunkBorderManager(chunkLockManager, unlockGui);
+            this.chunkBorderManager = new ChunkBorderManager(chunkLockManager, unlockGui, teamManager, progressTracker);
             
             // Set up team integration in BiomeUnlockRegistry
             try {

--- a/src/main/java/me/chunklock/PlayerListener.java
+++ b/src/main/java/me/chunklock/PlayerListener.java
@@ -384,7 +384,8 @@ public class PlayerListener implements Listener {
         Location centerSpawn = getCenterLocationOfChunk(startChunk);
         
         // Unlock the starting chunk
-        chunkLockManager.unlockChunk(startChunk);
+        UUID teamId = chunkLockManager.getTeamManager().getTeamLeader(player.getUniqueId());
+        chunkLockManager.unlockChunk(startChunk, teamId);
         
         // Set player data and teleport to center
         playerDataManager.setChunk(player.getUniqueId(), centerSpawn);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -322,6 +322,8 @@ team-settings:
   team-cost-multiplier: 0.15 # Additional cost per extra team member (15%)
   base-team-cost: 1.0 # Base multiplier for teams (1.0 = no change)
   max-cost-multiplier: 3.0 # Cap on total cost multiplier
+  contested-cost-multiplier: 3.0 # Cost multiplier when claiming enemy chunks
+  max-contested-claims-per-day: 5 # Limit on contested claims per team each day
 
   # Team Features
   enable-team-chat: true # Allow team chat functionality


### PR DESCRIPTION
## Summary
- track chunk ownership for teams
- multiply costs and enforce daily caps for contested chunk claims
- color chunk borders based on ownership
- track contested claims per team daily
- expose new config options

## Testing
- `mvn -DskipTests package`

------
https://chatgpt.com/codex/tasks/task_e_685474d790a4832ba2058b5abd23a4f9